### PR TITLE
Specify types for input parameters in fibRoute.ts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "jest": "^29.3.1",
         "supertest": "^6.3.3",
         "ts-jest": "^29.0.5",
-        "typescript": "^4.9.4"
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5495,9 +5495,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "jest": "^29.3.1",
     "supertest": "^6.3.3",
     "ts-jest": "^29.0.5",
-    "typescript": "^4.9.4"
+    "typescript": "^4.9.5"
   },
   "dependencies": {
     "express": "^4.17.1"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "jest": "^29.3.1",
     "supertest": "^6.3.3",
     "ts-jest": "^29.0.5",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.4"
   },
   "dependencies": {
     "express": "^4.17.1"

--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,8 +1,8 @@
 // Endpoint for querying the fibonacci numbers
-
+import { Request, Response } from "express";
 import fibonacci from "./fib";
 
-export default (req, res) => {
+export default (req : Request, res : Response) => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));


### PR DESCRIPTION
## Description

Translated src/fibRoute.ts from JavaScript to TypeScript by defining the types of two input parameters, `res` and `req` from the default type `any` to types `Response` and `Request`, respectively. Made changes to line 5 in reference to issue #1 (src/fibRoute.ts).

## Testing

Ran tests locally using `npm run test`.